### PR TITLE
export fails if products have no assigned category

### DIFF
--- a/Core/Service/Export.php
+++ b/Core/Service/Export.php
@@ -276,7 +276,9 @@ class Export
             $exportProduct->setName($article->getFieldData('oxtitle'));
             $exportProduct->setDescription($article->getLongDesc());
             $category = $article->getCategory();
-            $exportProduct->setCategory($category->getFieldData('oxtitle'));
+            if($category !== null) {
+                $exportProduct->setCategory($category->getFieldData('oxtitle'));
+            }
             $prices = $this->getExportProductPrices($article);
             $exportProduct->setPrices($prices);
             return $exportProduct;


### PR DESCRIPTION
If you want to export products to K3 that should not have a visible category, this is currently not possible because `$article->getCategory()` can also return `null`. In this case, the category's `getFieldData` function fails and causes the entire export to crash.